### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ const Migrations = [
 ]
 
 let client = new DynamoDB.DocumentClient()
+// if using aws-sdk v3 the client needs to be wrapped in the Dynamo class
+// let client = new Dynamo({ client: new DynamoDBClient({}) });
 
 exports.handler = async (event, context) => {
     let {action, args, config} = event


### PR DESCRIPTION
small comment about using aws-sdk v3 with migrations. If the client is a `DynamoDBClient` instance, any actions will fail with `Cannot invoke getCurrentVersion: Cannot read property 'describeTable' of undefined`.